### PR TITLE
build: add `WORKING_DIR` concept

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,9 +30,6 @@ jobs:
 
       - name: pytest
         run: make pytest
-      
-      - name: Fetch tarball
-        run: make syslog-ng.tar.gz
 
       - name: Build DB
         run: make db

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,9 @@ jobs:
 
       - name: pytest
         run: make pytest
+      
+      - name: Fetch tarball
+        run: make syslog-ng.tar.gz
 
       - name: Build DB
         run: make db

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ htmlcov/*
 .vscode
 dist
 
-syslog-ng.tar.gz
-syslog-ng/*
+working-dir/*
 syslog_ng_cfg_helper/syslog-ng-cfg-helper.db

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,7 @@ check: pytest linters
 format:
 	poetry run black $(SOURCEDIRS)
 
-syslog-ng.tar.gz:
-	rm -rf $(SYSLOG_NG_TARBALL_DIR)
+syslog-ng.tar.gz: clean
 	mkdir $(SYSLOG_NG_TARBALL_DIR)
 	wget $(SYSLOG_NG_TARBALL_URL) -O $(SYSLOG_NG_TARBALL_DIR).tar.gz
 	tar --strip-components=1 -C $(SYSLOG_NG_TARBALL_DIR) -xzf $(ROOT_DIR)/syslog-ng.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BISON_INSTALL_PATH := /usr/local
 SYSLOG_NG_VERSION := 4.4.0
 SYSLOG_NG_RELEASE_URL := https://github.com/syslog-ng/syslog-ng/releases/tag/syslog-ng-$(SYSLOG_NG_VERSION)
 SYSLOG_NG_TARBALL_URL := https://github.com/syslog-ng/syslog-ng/releases/download/syslog-ng-$(SYSLOG_NG_VERSION)/syslog-ng-$(SYSLOG_NG_VERSION).tar.gz
-SYSLOG_NG_TARBALL_DIR := $(ROOT_DIR)/syslog-ng
+SYSLOG_NG_SRC := $(ROOT_DIR)/syslog-ng
 
 DATABASE_FILE := $(ROOT_DIR)/syslog_ng_cfg_helper/syslog-ng-cfg-helper.db
 WORKING_DIR := $(ROOT_DIR)/working_dir
@@ -46,12 +46,17 @@ check: pytest linters
 format:
 	poetry run black $(SOURCEDIRS)
 
+tarball: clean
+	cd $(SYSLOG_NG_SRC)/ && $(SYSLOG_NG_SRC)/dbld/rules tarball
+	mkdir -p $(WORKING_DIR)/syslog-ng
+	tar --strip-components=1 -C $(WORKING_DIR)/syslog-ng -xzf $(SYSLOG_NG_SRC)/dbld/build/syslog-ng-*.tar.gz
+
 syslog-ng.tar.gz: clean
 	mkdir -p $(WORKING_DIR)/syslog-ng
 	wget $(SYSLOG_NG_TARBALL_URL) -O $(WORKING_DIR)/syslog-ng.tar.gz
 	tar --strip-components=1 -C $(WORKING_DIR)/syslog-ng -xzf $(WORKING_DIR)/syslog-ng.tar.gz
 
-db: syslog-ng.tar.gz
+db:
 	poetry run python $(ROOT_DIR)/syslog_ng_cfg_helper/build_db.py \
 		--source-dir=$(WORKING_DIR)/syslog-ng \
 		--output=$(DATABASE_FILE)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ SYSLOG_NG_VERSION := 4.4.0
 SYSLOG_NG_RELEASE_URL := https://github.com/syslog-ng/syslog-ng/releases/tag/syslog-ng-$(SYSLOG_NG_VERSION)
 SYSLOG_NG_TARBALL_URL := https://github.com/syslog-ng/syslog-ng/releases/download/syslog-ng-$(SYSLOG_NG_VERSION)/syslog-ng-$(SYSLOG_NG_VERSION).tar.gz
 SYSLOG_NG_TARBALL_DIR := $(ROOT_DIR)/syslog-ng
+
 DATABASE_FILE := $(ROOT_DIR)/syslog_ng_cfg_helper/syslog-ng-cfg-helper.db
+WORKING_DIR := $(ROOT_DIR)/working_dir
 
 bison:
 	wget https://ftp.gnu.org/gnu/bison/bison-3.7.6.tar.gz -O /tmp/bison.tar.gz
@@ -45,13 +47,13 @@ format:
 	poetry run black $(SOURCEDIRS)
 
 syslog-ng.tar.gz: clean
-	mkdir $(SYSLOG_NG_TARBALL_DIR)
-	wget $(SYSLOG_NG_TARBALL_URL) -O $(SYSLOG_NG_TARBALL_DIR).tar.gz
-	tar --strip-components=1 -C $(SYSLOG_NG_TARBALL_DIR) -xzf $(ROOT_DIR)/syslog-ng.tar.gz
+	mkdir -p $(WORKING_DIR)/syslog-ng
+	wget $(SYSLOG_NG_TARBALL_URL) -O $(WORKING_DIR)/syslog-ng.tar.gz
+	tar --strip-components=1 -C $(WORKING_DIR)/syslog-ng -xzf $(WORKING_DIR)/syslog-ng.tar.gz
 
 db: syslog-ng.tar.gz
 	poetry run python $(ROOT_DIR)/syslog_ng_cfg_helper/build_db.py \
-		--source-dir=$(SYSLOG_NG_TARBALL_DIR) \
+		--source-dir=$(WORKING_DIR)/syslog-ng \
 		--output=$(DATABASE_FILE)
 
 package: db
@@ -64,5 +66,5 @@ print-syslog-ng-release-url:
 	@echo $(SYSLOG_NG_RELEASE_URL)
 
 clean:
-	rm -rf $(SYSLOG_NG_TARBALL_DIR)
-	rm -f $(SYSLOG_NG_TARBALL_DIR).tar.gz
+	rm -rf $(WORKING_DIR)
+	rm -f $(WORKING_DIR).tar.gz

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BISON_INSTALL_PATH := /usr/local
 SYSLOG_NG_VERSION := 4.4.0
 SYSLOG_NG_RELEASE_URL := https://github.com/syslog-ng/syslog-ng/releases/tag/syslog-ng-$(SYSLOG_NG_VERSION)
 SYSLOG_NG_TARBALL_URL := https://github.com/syslog-ng/syslog-ng/releases/download/syslog-ng-$(SYSLOG_NG_VERSION)/syslog-ng-$(SYSLOG_NG_VERSION).tar.gz
-SYSLOG_NG_SOURCE_DIR := $(ROOT_DIR)/syslog-ng
+SYSLOG_NG_TARBALL_DIR := $(ROOT_DIR)/syslog-ng
 DATABASE_FILE := $(ROOT_DIR)/syslog_ng_cfg_helper/syslog-ng-cfg-helper.db
 
 bison:
@@ -45,14 +45,14 @@ format:
 	poetry run black $(SOURCEDIRS)
 
 syslog-ng.tar.gz:
-	rm -rf $(SYSLOG_NG_SOURCE_DIR)
-	mkdir $(SYSLOG_NG_SOURCE_DIR)
-	wget $(SYSLOG_NG_TARBALL_URL) -O $(SYSLOG_NG_SOURCE_DIR).tar.gz
-	tar --strip-components=1 -C $(SYSLOG_NG_SOURCE_DIR) -xzf $(ROOT_DIR)/syslog-ng.tar.gz
+	rm -rf $(SYSLOG_NG_TARBALL_DIR)
+	mkdir $(SYSLOG_NG_TARBALL_DIR)
+	wget $(SYSLOG_NG_TARBALL_URL) -O $(SYSLOG_NG_TARBALL_DIR).tar.gz
+	tar --strip-components=1 -C $(SYSLOG_NG_TARBALL_DIR) -xzf $(ROOT_DIR)/syslog-ng.tar.gz
 
 db: syslog-ng.tar.gz
 	poetry run python $(ROOT_DIR)/syslog_ng_cfg_helper/build_db.py \
-		--source-dir=$(SYSLOG_NG_SOURCE_DIR) \
+		--source-dir=$(SYSLOG_NG_TARBALL_DIR) \
 		--output=$(DATABASE_FILE)
 
 package: db
@@ -65,5 +65,5 @@ print-syslog-ng-release-url:
 	@echo $(SYSLOG_NG_RELEASE_URL)
 
 clean:
-	rm -rf $(SYSLOG_NG_SOURCE_DIR)
-	rm -f $(SYSLOG_NG_SOURCE_DIR).tar.gz
+	rm -rf $(SYSLOG_NG_TARBALL_DIR)
+	rm -f $(SYSLOG_NG_TARBALL_DIR).tar.gz

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The [Makefile](https://github.com/alltilla/syslog-ng-cfg-helper/blob/master/Make
   * `make check` runs the unit tests, style-checkers and linters.
   * `make format` formats the code.
   * `make db` downloads the syslog-ng release tarball and generates the option database.
+  * `make db SYSLOG_NG_SOURCE_DIR=/path/to/syslog-ng` creates a tarball from the state of the syslog-ng source dir and generates the option database.
   * `make package` creates the pip package.
 
 ## Community


### PR DESCRIPTION
Some considerations: 

- Should any target (other than `clean` itself) call `clean`?
- Can `working_dir`  be `build`  or something better/else?

Closes #15.